### PR TITLE
Fix/Remove scrollView bar in carousel posts

### DIFF
--- a/mobile/src/components/PostsScreen/PostCard.tsx
+++ b/mobile/src/components/PostsScreen/PostCard.tsx
@@ -43,6 +43,7 @@ export default function PostCard({ post }: { post: Post }) {
       <ScrollView
         ref={scrollViewRef}
         horizontal={true}
+        showsHorizontalScrollIndicator={false}
         pagingEnabled={true}
         style={{
           width: imageWidth,


### PR DESCRIPTION
- Apenas remoção da barra da Scrollview dos cards da tela de notícias, passando um `showsHorizontalScrollIndicator={false}`
